### PR TITLE
Use a tmpfs folder to speed compilation up

### DIFF
--- a/workflow-job
+++ b/workflow-job
@@ -256,10 +256,10 @@ flows["${sha1}"] = {
         node {
             parallel("Building Java 8 ${buildId}": {
                 sh "docker build --tag=${images.jamesCompile} dockerfiles/compilation/java-8"
-                sh "cd dockerfiles/; docker run ${verbose} --name=${containers.jamesCompile} ${dockerEnv} ${useMavenCache} --volumes-from=${containers.gitPublish} --volume=/destination ${images.jamesCompile} ${mergeBranch}"
+                sh "cd dockerfiles/; docker run ${verbose} --tmpfs /james-project:rw,size=4g --name=${containers.jamesCompile} ${dockerEnv} ${useMavenCache} --volumes-from=${containers.gitPublish} --volume=/destination ${images.jamesCompile} ${mergeBranch}"
             }, "Building Java 6 ${buildId}": {
                 sh "docker build --tag=${images.jamesCompileJava6} dockerfiles/compilation/java-6"
-                sh "cd dockerfiles/; docker run ${verbose} --name=${containers.jamesCompileJava6} ${dockerEnv} ${useMavenCache} --volumes-from=${containers.gitPublish} --volume=/destination ${images.jamesCompileJava6} -s ${mergeBranch}"
+                sh "cd dockerfiles/; docker run ${verbose} --tmpfs /james-project:rw,size=4g --name=${containers.jamesCompileJava6} ${dockerEnv} ${useMavenCache} --volumes-from=${containers.gitPublish} --volume=/destination ${images.jamesCompileJava6} -s ${mergeBranch}"
             })
             building.success();
         }


### PR DESCRIPTION
I finally managed to find how to cleanly mount a tmpfs inside a docker container.
So I guess we have here an easy speedup for our tests.

Note : It is not as fast as having the whole docker container in tmpfs, but it is still fine !
