### PR TITLE
redifining gitlabToken brakes (and doesn't seem useful

### DIFF
--- a/workflow-job
+++ b/workflow-job
@@ -508,7 +508,6 @@ flows["${sha1}"] = {
 		    }
 
                     if (packagageOnGitlab) {
-                        def gitlabToken = gitlabToken();
                         sh """curl
 			   |-X POST
 			   |-Ftoken=${gitlabToken}

--- a/workflow-job
+++ b/workflow-job
@@ -508,9 +508,10 @@ flows["${sha1}"] = {
 		    }
 
                     if (packagageOnGitlab) {
+                        def gToken = gitlabToken();
                         sh """curl
 			   |-X POST
-			   |-Ftoken=${gitlabToken}
+			   |-Ftoken=${gToken}
 			   |-F'ref=master'
 			   |-F'variables[REPO_NAME]=oncommit'
 			   |-F'variables[SOURCE_REPO]=https://github.com/linagora/james-project'


### PR DESCRIPTION
```

WorkflowScript: 511: The current scope already contains a variable of the name gitlabToken
 @ line 511, column 29.
                           def gitlabToken = gitlabToken();
```
