### PR TITLE
add logs to see the presence of glowroot plugins, admin.json and run_…

### DIFF
--- a/workflow-job
+++ b/workflow-job
@@ -528,14 +528,21 @@ flows["${sha1}"] = {
                 if (isTag()) {
                     buildVolumeFromTag(this)
                 } else {
+                    sh "echo 'cassandra-rabbitmq-ldap content before merge'"
+                    sh "ls -R dockerfiles/run/guice/cassandra-rabbitmq-ldap"
                     merge(this)
+                    sh "echo 'cassandra-rabbitmq-ldap content after merge'"
+                    sh "ls -R dockerfiles/run/guice/cassandra-rabbitmq-ldap"
                 }
+
+
                 merging.success()
                 rabbitMQProductExists = fileExists 'dockerfiles/run/guice/cassandra-rabbitmq-ldap'
                 memoryProductExists = fileExists 'dockerfiles/run/guice/memory'
 
                 compile()
-
+                sh "echo 'cassandra-rabbitmq-ldap content after compile'"
+                sh "ls -R dockerfiles/run/guice/cassandra-rabbitmq-ldap"
                 deployGuiceCassandra()
                 testGuiceCassandra()
 


### PR DESCRIPTION
in order to debug the copy of the files from the glowroot PR.
The glowroot/plugins, glowroot/admin.json and run_sh failed to be copied from the test container.
And they seems to not be present in */destination when building the docker images.

the glowroot jar which is copied during the compile.sh is present.