### PR TITLE
Ci for glowroot

### DIFF
--- a/workflow-job
+++ b/workflow-job
@@ -265,32 +265,51 @@ class Command {
     }
 }
 
-jarPathCassandra = '/cassandra/destination/james-server-cassandra-guice.jar'
-libPathCassandra = '/cassandra/destination/james-server-cassandra-guice.lib'
-jarPathCassandraLdap = '/cassandra/destination/james-server-cassandra-ldap-guice.jar'
-libPathCassandraLdap = '/cassandra/destination/james-server-cassandra-ldap-guice.lib'
-cliJarPathCassandra = '/cassandra/destination/james-server-cli.jar'
-clilibPathCassandra = '/cassandra/destination/james-server-cli.lib'
+productCassandra = 'cassandra'
+productCassandraRabbitMQ = 'cassandra-rabbitmq'
+productCassandraRabbitMQLdap = 'cassandra-rabbitmq-ldap'
+productJPA = 'jpa'
+productMemory = 'memory'
 
-jarPathCassandraRabbitMQ = '/cassandra-rabbitmq/destination/james-server-cassandra-rabbitmq-guice.jar'
-libPathCassandraRabbitMQ = '/cassandra-rabbitmq/destination/james-server-cassandra-rabbitmq-guice.lib'
-cliJarPathCassandraRabbitMQ = '/cassandra-rabbitmq/destination/james-server-cli.jar'
-clilibPathCassandraRabbitMQ = '/cassandra-rabbitmq/destination/james-server-cli.lib'
+jarPathCassandra = pathInDestination(productCassandra, 'james-server-cassandra-guice.jar')
+libPathCassandra = pathInDestination(productCassandra, 'james-server-cassandra-guice.lib')
 
-jarPathCassandraRabbitMQLdap = '/cassandra-rabbitmq-ldap/destination/james-server-cassandra-rabbitmq-ldap-guice.jar'
-libPathCassandraRabbitMQLdap = '/cassandra-rabbitmq-ldap/destination/james-server-cassandra-rabbitmq-ldap-guice.lib'
-cliJarPathCassandraRabbitMQLdap = '/cassandra-rabbitmq-ldap/destination/james-server-cli.jar'
-clilibPathCassandraRabbitMQLdap = '/cassandra-rabbitmq-ldap/destination/james-server-cli.lib'
+jarPathCassandraLdap = pathInDestination(productCassandra, 'james-server-cassandra-ldap-guice.jar')
+libPathCassandraLdap = pathInDestination(productCassandra, 'james-server-cassandra-ldap-guice.lib')
+cliJarPathCassandra = getCliJarPath(productCassandra)
+clilibPathCassandra = getCliLibPath(productCassandra)
 
-jarPathJPA = '/jpa/destination/james-server-jpa-guice.jar'
-libPathJPA = '/jpa/destination/james-server-jpa-guice.lib'
-cliJarPathJPA = '/jpa/destination/james-server-cli.jar'
-clilibPathJPA = '/jpa/destination/james-server-cli.lib'
+jarPathCassandraRabbitMQ = pathInDestination(productCassandraRabbitMQ, 'james-server-cassandra-rabbitmq-guice.jar')
+libPathCassandraRabbitMQ = pathInDestination(productCassandraRabbitMQ, 'james-server-cassandra-rabbitmq-guice.lib')
+cliJarPathCassandraRabbitMQ = getCliJarPath(productCassandraRabbitMQ)
+clilibPathCassandraRabbitMQ = getCliLibPath(productCassandraRabbitMQ)
 
-jarPathMemory = '/memory/destination/james-server-memory-guice.jar'
-libPathMemory = '/memory/destination/james-server-memory-guice.lib'
-cliJarPathMemory = '/memory/destination/james-server-cli.jar'
-clilibPathMemory = '/memory/destination/james-server-cli.lib'
+jarPathCassandraRabbitMQLdap = pathInDestination(productCassandraRabbitMQLdap, 'james-server-cassandra-rabbitmq-ldap-guice.jar')
+libPathCassandraRabbitMQLdap = pathInDestination(productCassandraRabbitMQLdap, 'james-server-cassandra-rabbitmq-ldap-guice.lib')
+cliJarPathCassandraRabbitMQLdap = getCliJarPath(productCassandraRabbitMQLdap)
+clilibPathCassandraRabbitMQLdap = getCliLibPath(productCassandraRabbitMQLdap)
+
+jarPathJPA = pathInDestination(productJPA, 'james-server-jpa-guice.jar')
+libPathJPA = pathInDestination(productJPA, 'james-server-jpa-guice.lib')
+cliJarPathJPA = getCliJarPath(productJPA)
+clilibPathJPA = getCliLibPath(productJPA)
+
+jarPathMemory = pathInDestination(productMemory, 'james-server-memory-guice.jar')
+libPathMemory = pathInDestination(productMemory, 'james-server-memory-guice.lib')
+cliJarPathMemory = getCliJarPath(productMemory)
+clilibPathMemory = getCliLibPath(productMemory)
+
+private getCliJarPath(productMemory) {
+    pathInDestination(productMemory, 'james-server-cli.jar')
+}
+
+private getCliLibPath(product) {
+    pathInDestination(product, 'james-server-cli.lib')
+}
+
+def pathInDestination(product, file) {
+    return "$product/destination/$file"
+}
 
 keystorePath = '/keys/keystore'
 jamesCliWithOptions = 'java -jar /root/james-cli.jar -h 127.0.0.1'

--- a/workflow-job
+++ b/workflow-job
@@ -276,28 +276,18 @@ libPathCassandra = pathInDestination(productCassandra, 'james-server-cassandra-g
 
 jarPathCassandraLdap = pathInDestination(productCassandra, 'james-server-cassandra-ldap-guice.jar')
 libPathCassandraLdap = pathInDestination(productCassandra, 'james-server-cassandra-ldap-guice.lib')
-cliJarPathCassandra = getCliJarPath(productCassandra)
-clilibPathCassandra = getCliLibPath(productCassandra)
 
 jarPathCassandraRabbitMQ = pathInDestination(productCassandraRabbitMQ, 'james-server-cassandra-rabbitmq-guice.jar')
 libPathCassandraRabbitMQ = pathInDestination(productCassandraRabbitMQ, 'james-server-cassandra-rabbitmq-guice.lib')
-cliJarPathCassandraRabbitMQ = getCliJarPath(productCassandraRabbitMQ)
-clilibPathCassandraRabbitMQ = getCliLibPath(productCassandraRabbitMQ)
 
 jarPathCassandraRabbitMQLdap = pathInDestination(productCassandraRabbitMQLdap, 'james-server-cassandra-rabbitmq-ldap-guice.jar')
 libPathCassandraRabbitMQLdap = pathInDestination(productCassandraRabbitMQLdap, 'james-server-cassandra-rabbitmq-ldap-guice.lib')
-cliJarPathCassandraRabbitMQLdap = getCliJarPath(productCassandraRabbitMQLdap)
-clilibPathCassandraRabbitMQLdap = getCliLibPath(productCassandraRabbitMQLdap)
 
 jarPathJPA = pathInDestination(productJPA, 'james-server-jpa-guice.jar')
 libPathJPA = pathInDestination(productJPA, 'james-server-jpa-guice.lib')
-cliJarPathJPA = getCliJarPath(productJPA)
-clilibPathJPA = getCliLibPath(productJPA)
 
 jarPathMemory = pathInDestination(productMemory, 'james-server-memory-guice.jar')
 libPathMemory = pathInDestination(productMemory, 'james-server-memory-guice.lib')
-cliJarPathMemory = getCliJarPath(productMemory)
-clilibPathMemory = getCliLibPath(productMemory)
 
 private getCliJarPath(productMemory) {
     pathInDestination(productMemory, 'james-server-cli.jar')
@@ -606,6 +596,15 @@ def compile() {
     testingJava8.success()
 }
 
+def copyFilesFromCompilationContainer(product, jarPath, libPath) {
+    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.keystore}:${keystorePath} destination/conf"
+    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:$jarPath destination"
+    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:$libPath destination"
+    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:${getCliJarPath(product)} destination"
+    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:${getCliLibPath(product)} destination"
+
+}
+
 def deployGuiceCassandra() {
     // Start common dependencies
     sh "docker run --detach=true --name=${containers.cassandra} ${images.cassandra}"
@@ -625,11 +624,7 @@ def deployGuiceCassandra() {
     deployingGuiceCassandraRabbitMQ.success()
     testingGuiceCassandraRabbitMQ.success()
 
-    sh "cd dockerfiles/run/guice/cassandra; docker cp ${containers.keystore}:${keystorePath} destination/conf"
-    sh "cd dockerfiles/run/guice/cassandra; docker cp ${containers.jamesTest}:${jarPathCassandra} destination"
-    sh "cd dockerfiles/run/guice/cassandra; docker cp ${containers.jamesTest}:${libPathCassandra} destination"
-    sh "cd dockerfiles/run/guice/cassandra; docker cp ${containers.jamesTest}:${cliJarPathCassandra} destination"
-    sh "cd dockerfiles/run/guice/cassandra; docker cp ${containers.jamesTest}:${clilibPathCassandra} destination"
+    copyFilesFromCompilationContainer(productCassandra, jarPathCassandra, libPathCassandra)
     sh "cd dockerfiles/run/guice/cassandra; docker build --tag=${images.jamesCassandra} ."
     dockeringGuiceCassandra.success()
 
@@ -657,20 +652,12 @@ def deployGuiceCassandra() {
 
 def deployGuiceRabbitMQ() {
     //Dockering Guice Server with Cassandra + RabbitMQ + Swift + Ldap
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq-ldap; docker cp ${containers.keystore}:${keystorePath} destination/conf"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq-ldap; docker cp ${containers.jamesTest}:${jarPathCassandraRabbitMQLdap} destination"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq-ldap; docker cp ${containers.jamesTest}:${libPathCassandraRabbitMQLdap} destination"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq-ldap; docker cp ${containers.jamesTest}:${cliJarPathCassandraRabbitMQLdap} destination"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq-ldap; docker cp ${containers.jamesTest}:${clilibPathCassandraRabbitMQLdap} destination"
+    copyFilesFromCompilationContainer(productCassandraRabbitMQLdap, jarPathCassandraRabbitMQLdap, libPathCassandraRabbitMQLdap)
 
     sh "cd dockerfiles/run/guice/cassandra-rabbitmq-ldap; docker build --tag=${images.jamesCassandraRabbitMQLdap} ."
 
     //Deploying Guice Server with Cassandra + RabbitMQ + Swift
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq; docker cp ${containers.keystore}:${keystorePath} destination/conf"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq; docker cp ${containers.jamesTest}:${jarPathCassandraRabbitMQ} destination"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq; docker cp ${containers.jamesTest}:${libPathCassandraRabbitMQ} destination"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq; docker cp ${containers.jamesTest}:${cliJarPathCassandraRabbitMQ} destination"
-    sh "cd dockerfiles/run/guice/cassandra-rabbitmq; docker cp ${containers.jamesTest}:${clilibPathCassandraRabbitMQ} destination"
+    copyFilesFromCompilationContainer(productCassandraRabbitMQ, jarPathCassandraRabbitMQ, libPathCassandraRabbitMQ)
     sh "docker run --detach=true --name=${containers.rabbitmq} ${images.rabbitmq}"
     sh "docker run --detach=true --name=${containers.swift} ${images.swift}"
 
@@ -705,12 +692,7 @@ def testGuiceCassandra() {
 }
 
 def deployGuiceJPA() {
-    sh "cd dockerfiles/run/guice/jpa; docker cp ${containers.keystore}:${keystorePath} destination/conf"
-    sh "cd dockerfiles/run/guice/jpa; docker cp ${containers.jamesTest}:${jarPathJPA} destination"
-    sh "cd dockerfiles/run/guice/jpa; docker cp ${containers.jamesTest}:${libPathJPA} destination"
-    sh "cd dockerfiles/run/guice/jpa; docker cp ${containers.jamesTest}:${cliJarPathJPA} destination"
-    sh "cd dockerfiles/run/guice/jpa; docker cp ${containers.jamesTest}:${clilibPathJPA} destination"
-
+    copyFilesFromCompilationContainer(productJPA, jarPathJPA, libPathJPA)
     sh "cd dockerfiles/run/guice/jpa; docker build --tag=${images.jamesJPA} ."
 
     dockeringGuiceJPA.success()
@@ -771,12 +753,7 @@ def testSpringJPA() {
 }
 
 def deployMemory() {
-    sh "cd dockerfiles/run/guice/memory; docker cp ${containers.keystore}:${keystorePath} destination/conf"
-    sh "cd dockerfiles/run/guice/memory; docker cp ${containers.jamesTest}:${jarPathMemory} destination"
-    sh "cd dockerfiles/run/guice/memory; docker cp ${containers.jamesTest}:${libPathMemory} destination"
-    sh "cd dockerfiles/run/guice/memory; docker cp ${containers.jamesTest}:${cliJarPathMemory} destination"
-    sh "cd dockerfiles/run/guice/memory; docker cp ${containers.jamesTest}:${clilibPathMemory} destination"
-
+    copyFilesFromCompilationContainer(productMemory, jarPathMemory, libPathMemory)
     sh "cd dockerfiles/run/guice/memory; docker build --tag=${images.jamesMemory} ."
 
     dockeringMemory.success()
@@ -804,12 +781,7 @@ def testMemory() {
 }
 
 def buildGuiceCassandraLdap() {
-    sh "cd dockerfiles/run/guice/cassandra-ldap; docker cp ${containers.keystore}:${keystorePath} destination/conf"
-    sh "cd dockerfiles/run/guice/cassandra-ldap; docker cp ${containers.jamesTest}:${jarPathCassandraLdap} destination"
-    sh "cd dockerfiles/run/guice/cassandra-ldap; docker cp ${containers.jamesTest}:${libPathCassandraLdap} destination"
-    sh "cd dockerfiles/run/guice/cassandra-ldap; docker cp ${containers.jamesTest}:${cliJarPathCassandra} destination"
-    sh "cd dockerfiles/run/guice/cassandra-ldap; docker cp ${containers.jamesTest}:${clilibPathCassandra} destination"
-
+   copyFilesFromCompilationContainer(productCassandra, jarPathCassandraLdap, libPathCassandraLdap)
     sh "cd dockerfiles/run/guice/cassandra-ldap; docker build --tag=${images.jamesCassandraLdap} ."
 
     dockeringGuiceCassandraLdap.success()

--- a/workflow-job
+++ b/workflow-job
@@ -266,6 +266,7 @@ class Command {
 }
 
 productCassandra = 'cassandra'
+productCassandraLdap = '"cassandra-ldap"'
 productCassandraRabbitMQ = 'cassandra-rabbitmq'
 productCassandraRabbitMQLdap = 'cassandra-rabbitmq-ldap'
 productJPA = 'jpa'
@@ -295,6 +296,34 @@ private getCliJarPath(productMemory) {
 
 private getCliLibPath(product) {
     pathInDestination(product, 'james-server-cli.lib')
+}
+
+def runJamesScriptPath(product) {
+    pathInDestination(product, 'run_james.sh')
+}
+
+def glowrootPluginsPath(product) {
+    pathForGlowrootFile(product, 'plugins')
+}
+
+def glowrootJarPath(product) {
+    pathForGlowrootFile(product, 'glowroot.jar')
+}
+
+def glowrootCollectorJarPath(product) {
+    pathForGlowrootFile(product, 'lib/glowroot-embedded-collector.jar')
+}
+
+def glowrootLogginJarPath(product) {
+    pathForGlowrootFile(product, 'lib/glowroot-logging-logstash.jar')
+}
+
+def glowrootAdminJsonPath(product) {
+    pathForGlowrootFile(product, 'admin.json')
+}
+
+def pathForGlowrootFile(product, file) {
+    pathInDestination(product, "glowroot/$file")
 }
 
 def pathInDestination(product, file) {
@@ -597,11 +626,21 @@ def compile() {
 }
 
 def copyFilesFromCompilationContainer(product, jarPath, libPath) {
-    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.keystore}:${keystorePath} destination/conf"
-    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:$jarPath destination"
-    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:$libPath destination"
-    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:${getCliJarPath(product)} destination"
-    sh "cd dockerfiles/run/guice/$product; docker cp ${containers.jamesTest}:${getCliLibPath(product)} destination"
+    copyFilesFromCompilationContainer(product, product, jarPath, libPath)
+}
+
+def copyFilesFromCompilationContainer(destinationProduct, sourceProduct, jarPath, libPath) {
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.keystore}:${keystorePath} destination/conf"
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.jamesTest}:$jarPath destination"
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.jamesTest}:$libPath destination"
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.jamesTest}:${getCliJarPath(sourceProduct)} destination"
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.jamesTest}:${getCliLibPath(sourceProduct)} destination"
+
+    sh "cd dockerfiles/run/guice; mkdir ${pathForGlowrootFile(destinationProduct, "lib")} || true"
+
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.jamesTest}:${glowrootJarPath(sourceProduct)} destination/glowroot || true"
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.jamesTest}:${glowrootCollectorJarPath(sourceProduct)} destination/glowroot/lib || true"
+    sh "cd dockerfiles/run/guice/$destinationProduct; docker cp ${containers.jamesTest}:${glowrootLogginJarPath(sourceProduct)} destination/glowroot/lib || true"
 
 }
 
@@ -781,7 +820,7 @@ def testMemory() {
 }
 
 def buildGuiceCassandraLdap() {
-   copyFilesFromCompilationContainer(productCassandra, jarPathCassandraLdap, libPathCassandraLdap)
+   copyFilesFromCompilationContainer(productCassandraLdap, productCassandra, jarPathCassandraLdap, libPathCassandraLdap)
     sh "cd dockerfiles/run/guice/cassandra-ldap; docker build --tag=${images.jamesCassandraLdap} ."
 
     dockeringGuiceCassandraLdap.success()


### PR DESCRIPTION
The fix between the last PR are : 

in copyFilesFromCompilationContainer we create the glowroot/lib directory before copying into it, which avoid the errors found when running the ci against JAMES-2773.

We now have a special case of this same method to handle the case of the cassandra-ldap product which get the file from a 'cassandra' directory in the container, but copy it in the 'cassandra-ldap' directory. Which is the bug encountered when running the ci against the others PRs.