### PR TITLE
Publish images to DockerHub

### DIFF
--- a/build-github-tag
+++ b/build-github-tag
@@ -4,12 +4,13 @@ import groovy.transform.TupleConstructor
 class TagOnRepo {
     String repo
     String tag
+    boolean latest = false
 }
 
 def tagsToBuild = [
         new TagOnRepo('linagora/james-project', 'openpaas-1.4.0'),
         new TagOnRepo('linagora/james-project', 'openpaas-1.4.1'),
-        new TagOnRepo('linagora/james-project', 'james-project-3.3.0'),
+        new TagOnRepo('linagora/james-project', 'james-project-3.3.0', latest: true),
         new TagOnRepo('linagora/james-project', 'openpaas-1.4.8'),
         new TagOnRepo('linagora/james-project', 'openpaas-1.5.1')
 ]
@@ -34,7 +35,7 @@ tagsToBuild.each {
                     [buildStepFailure: 'FAILURE',
                      failure         : 'FAILURE',
                      unstable        : 'UNSTABLE']) {
-                    predefinedProps([repoURL: repository, tagName: tagOnRepo.tag, originalBranch: ""])
+                    predefinedProps([repoURL: repository, tagName: tagOnRepo.tag, originalBranch: "", isLatest: tagOnRepo.latest])
                 }
             }
         }

--- a/workflow-job
+++ b/workflow-job
@@ -12,6 +12,7 @@ import org.kohsuke.github.GHRepository
 // or $tagName parameter: specifies the tag to build
 // or $sha1 parameter: specifies the actual commit
 // $originalBranch: the branch used for merge (optional)
+// $isLatest: is it the latest stable release
 
 hostname = 'james.linagora.com'
 maxRetries = 120
@@ -393,7 +394,7 @@ def tag = {
     if (isMaster()) {
         return "branch-master"
     }
-    return "${workingBranch}"
+    return null
 }
 
 dockerTag = tag()
@@ -860,6 +861,17 @@ def publish() {
         sh "docker login -u ${dockerUser} -p ${dockerPassword}"
     }
 
+    if (dockerTag) {
+        publishTag(dockerTag)
+    }
+    if (isLatest == "true") {
+        publishTag("latest")
+    }
+
+    publishing.success()
+}
+
+def publishTag(dockerTag) {
     sh "docker tag ${images.jamesCassandra} linagora/james-project:${dockerTag}"
     sh "docker push linagora/james-project:${dockerTag}"
 
@@ -889,6 +901,4 @@ def publish() {
         sh "docker tag ${images.jamesCassandraRabbitMQ} linagora/james-rabbitmq-project:${dockerTag}"
         sh "docker push linagora/james-rabbitmq-project:${dockerTag}"
     }
-
-    publishing.success()
 }

--- a/workflow-job
+++ b/workflow-job
@@ -391,7 +391,7 @@ def tag = {
         return "${tagName}"
     }
     if (isMaster()) {
-        return "latest"
+        return "branch-master"
     }
     return "${workingBranch}"
 }


### PR DESCRIPTION
This PR has two different goals:
- rename the `latest` image to `branch-master`
- publish `latest` image as the latest stable release