### PR TITLE
Waiting error output hurts log readability

### DIFF
--- a/workflow-job
+++ b/workflow-job
@@ -343,7 +343,7 @@ def waitForCommandSuccess(command, maxRetries) {
     def tries = 0
     while (tries++ < maxRetries) {
         try {
-            sh command
+            sh "echo 'Waiting ${command}'; " + command + " &> /dev/null"
             return true
         } catch (Exception e) {
             if (tries >= maxRetries) {


### PR DESCRIPTION
We are awaiting by calling james-cli which is failing and thus printing
in a very verbose fashion the cli-help in the CI output, which is not very
constructive anyway.