### PR TITLE
Add a build argument for Spring Dockerfile version

### DIFF
--- a/workflow-job
+++ b/workflow-job
@@ -787,7 +787,7 @@ def deploySpringJPA() {
 
     sh "cd dockerfiles/run/spring; docker cp ${containers.jamesTest}:${zipPath} destination"
 
-    sh "cd dockerfiles/run/spring; docker build --tag=${images.jamesSpring} ."
+    sh "cd dockerfiles/run/spring; docker build --tag=${images.jamesSpring} --build-arg VERSION=${jamesVersion} ."
 
     dockeringSpringJPA.success()
 


### PR DESCRIPTION
Upon a release we need to change simultaneously maven version and the one
within Spring dockerfile (which relies on hard-coded version positionned
by the assembly plugin). This results in broken build post-release as well
as difficulties into building a specific tag when forgotten.

With this changeset we can specify a build argument upon Spring docker
image creation from CI environment, in order to use the right version
without needing code changes. As version can be detected from build files,
this means that we will avoid that pitfall.